### PR TITLE
[Enhancement] Add DecodingError as associated type in decode enum case in ResponseError

### DIFF
--- a/Sources/CoreNetworking/HTTPClient.swift
+++ b/Sources/CoreNetworking/HTTPClient.swift
@@ -22,13 +22,20 @@ public class HTTPClient {
         }
         switch response.statusCode {
         case 200...299:
-            guard let decodedResponse = try? jsonDecoder.decode(
-                responseType,
-                from: data
-            ) else {
-                throw Request.RequestError.decode
+            do {
+                let decodedResponse = try jsonDecoder.decode(
+                    responseType,
+                    from: data
+                )
+                
+                return decodedResponse
+            } catch {
+                guard let decodingError = error as? DecodingError else {
+                    throw Request.RequestError.decode()
+                }
+                
+                throw Request.RequestError.decode(decodingError)
             }
-            return decodedResponse
         case 401:
             throw Request.RequestError.unauthorized
         default:

--- a/Sources/CoreNetworking/Request.swift
+++ b/Sources/CoreNetworking/Request.swift
@@ -61,15 +61,15 @@ public extension Request {
     }
 
     enum RequestError: Error {
-        case decode
+        case decode(DecodingError? = nil)
         case noResponse
         case unauthorized
         case unexpectedStatusCode
 
         var customMessage: String {
             switch self {
-            case .decode:
-                return "Decode error"
+            case .decode(let underlyingError):
+                return "Decode error: \(String(describing: underlyingError))"
             case .unauthorized:
                 return "Session expired"
             default:

--- a/Tests/CoreNetworkingTests/CoreNetworkingTests.swift
+++ b/Tests/CoreNetworkingTests/CoreNetworkingTests.swift
@@ -36,8 +36,17 @@ final class CoreNetworkingTests: XCTestCase {
         do {
             _ = try await service.fetchCatFact()
             XCTFail("Should have thrown")
+        } catch let Request.RequestError.decode(DecodingError.keyNotFound(key, context)?) {
+            XCTAssertEqual(key.intValue, nil)
+            XCTAssertEqual(key.stringValue, "fact")
+            XCTAssertEqual(context.codingPath.count, 0)
+            XCTAssertEqual(
+                context.debugDescription,
+                "No value associated with key CodingKeys(stringValue: \"fact\", intValue: nil) (\"fact\")."
+            )
+            XCTAssertNil(context.underlyingError)
         } catch {
-            XCTAssertEqual(error as? Request.RequestError, .decode)
+            XCTFail("Should have thrown RequestError.decode error")
         }
     }
 }


### PR DESCRIPTION
Hello! I'm using this package for a side project, so thank you for open sourcing it 🙂

This PR is a proposal to add `Swift.DecodingError` as an associated value in the `.decode` enum case in `ResponseError`. The reason: sometimes, when you're debugging an API call with lots of properties and sub-objects, is useful to inspect the Xcode Console and see which property doesn't have the correct type. Without exposing `Swift.DecodingError`, this ability is hidden by the package.

It's just a proposal so feel free to close it if you don't consider it's applicable for your package!